### PR TITLE
Link protoMOMxx to TIM

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -16,6 +16,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Build and run tests
         run: ./build_and_run.sh --tests --fresh

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -22,5 +22,5 @@ jobs:
       - name: Build and run tests
         run: ./build_and_run.sh --tests --fresh
 
-      - name: Run infra tests on 2 MPI ranks
-        run: mpiexec -n 2 ./build/tests/config_src/infra/test_infra
+      - name: Run the multi-rank tests on 2 MPI ranks
+        run: ctest --test-dir ./build -L mpi --output-on-failure

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -21,3 +21,6 @@ jobs:
 
       - name: Build and run tests
         run: ./build_and_run.sh --tests --fresh
+
+      - name: Run infra tests on 2 MPI ranks
+        run: mpiexec -n 2 ./build/tests/config_src/infra/test_infra

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "extern/TIM"]
+	path = extern/TIM
+	url = https://github.com/TURBO-ESM/TIM.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,22 @@ endif()
 
 include(cmake/protomomtarget.cmake)
 
+# TIM (tim/cpp) is a self-contained CMake subproject yielding the TIM::tim
+# target. Added after AMReX is found, so tim/cpp's guarded find_package(AMReX)
+# is skipped and the AMReX already found by protoMOMxx is used. TIM_SOURCE_DIR
+# defaults to the bundled extern/TIM submodule, but can be overridden to point
+# at an existing TIM checkout.
+set(TIM_SOURCE_DIR "${CMAKE_SOURCE_DIR}/extern/TIM" CACHE PATH
+  "Path to the TIM checkout (defaults to the extern/TIM submodule).")
+if(NOT EXISTS "${TIM_SOURCE_DIR}/tim/cpp/CMakeLists.txt")
+  message(FATAL_ERROR
+    "TIM sources not found under '${TIM_SOURCE_DIR}/tim/cpp'.\n"
+    "If you cloned protoMOMxx without submodules, initialize them:\n"
+    "    git submodule update --init --recursive\n"
+    "or point -DTIM_SOURCE_DIR=<path> at an existing TIM checkout.")
+endif()
+add_subdirectory(${TIM_SOURCE_DIR}/tim/cpp ${CMAKE_BINARY_DIR}/extern/TIM/tim_cpp)
+
 add_subdirectory(src/framework)
 add_subdirectory(src/core)
 add_subdirectory(config_src/drivers/solo_driver)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ if(NOT EXISTS "${TIM_SOURCE_DIR}/tim/cpp/CMakeLists.txt")
     "    git submodule update --init --recursive\n"
     "or point -DTIM_SOURCE_DIR=<path> at an existing TIM checkout.")
 endif()
-add_subdirectory(${TIM_SOURCE_DIR}/tim/cpp ${CMAKE_BINARY_DIR}/extern/TIM/tim_cpp)
+add_subdirectory("${TIM_SOURCE_DIR}/tim/cpp" "${CMAKE_BINARY_DIR}/extern/TIM/tim_cpp")
 
 add_subdirectory(src/framework)
 add_subdirectory(src/core)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ modules before calling `build_and_run.sh`:
 | `--gpu`         | Build with the CUDA backend (loads `cuda/12.9.0`, builds AMReX into `dependencies/amrex-cuda`, and protoMOMxx into `build-gpu`) |
 | `--tests`       | Build and run the unit tests instead of the `protoMOMxx` executable |
 | `--system-tests`| Build and run the (slower) system tests instead, e.g. full-executable smoke/regression tests |
-| `--all-tests`   | Build and run both the unit and system tests |
+| `--mpi-tests`   | Build and run the multi-rank tests instead, i.e. those launched under `mpiexec` |
+| `--all-tests`   | Build and run all test categories (unit, mpi, and system) |
 | `--debug`       | Build with `CMAKE_BUILD_TYPE=Debug` instead of `Release`       |
 | `--fresh`       | Force a fresh CMake configuration of protoMOMxx even if the build directory already exists |
 | `--jobs N`      | Build with `N` parallel jobs (default: 2)                      |
@@ -72,7 +73,8 @@ full list, e.g. `JOBS`, `BUILD_DIR`, `CMAKE_BUILD_TYPE`, `PROTOMOM_ADD_TEST_TARG
 ```bash
 . ./create_env.sh
 CMAKE_PREFIX_PATH="${AMREX_ROOT}/install" PROTOMOM_ADD_TEST_TARGETS=ON . ./build.sh
-ctest --test-dir build -L unit    # fast unit tests
+ctest --test-dir build -L unit    # fast unit tests (single rank, no launcher)
+ctest --test-dir build -L mpi     # multi-rank tests, launched under mpiexec
 ctest --test-dir build -L system  # slower full-executable system tests
 ctest --test-dir build            # everything
 ```

--- a/README.md
+++ b/README.md
@@ -5,6 +5,21 @@ for code modernization and GPU acceleration.
 
 The code is currently in *very* early stages of development, and is ***not yet functional.***. The goal of this project is to explore the design and implementation of a modernized MOM codebase, and to provide a testbed for new features and optimizations.
 
+# Cloning
+
+protoMOMxx includes TIM as a git submodule at `extern/TIM`, so clone recursively:
+
+```bash
+git clone --recurse-submodules https://github.com/TURBO-ESM/protoMOMxx.git
+```
+
+If you already cloned without `--recurse-submodules`, initialize the submodule
+in place:
+
+```bash
+git submodule update --init --recursive
+```
+
 # Quick Start
 
 The easiest way to build and run protoMOMxx is via the `build_and_run.sh` script, which

--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -6,6 +6,7 @@
 : ${PROTOMOM_ALL_TESTS:="OFF"}
 : ${PROTOMOM_SYSTEM_TESTS:="OFF"}
 : ${PROTOMOM_UNIT_TESTS:="OFF"}
+: ${PROTOMOM_MPI_TESTS:="OFF"}
 : ${CMAKE_BUILD_TYPE:="Release"}
 : ${AMReX_GPU_BACKEND:="NONE"}
 : ${BUILD_DIR:="${ROOTDIR}/build"}
@@ -24,6 +25,8 @@ while [[ "$#" -gt 0 ]]; do
             PROTOMOM_UNIT_TESTS="ON" ;;
         --system-tests)
             PROTOMOM_SYSTEM_TESTS="ON" ;;
+        --mpi-tests)
+            PROTOMOM_MPI_TESTS="ON" ;;
         --all-tests)
             PROTOMOM_ALL_TESTS="ON" ;;
         --debug)
@@ -51,6 +54,7 @@ CMAKE_PREFIX_PATH="${AMREX_ROOT}/install"
 # Tell CMake to build the test targets whenever any test category was requested.
 if [[ "${PROTOMOM_UNIT_TESTS}" == "ON" \
       || "${PROTOMOM_SYSTEM_TESTS}" == "ON" \
+      || "${PROTOMOM_MPI_TESTS}" == "ON" \
       || "${PROTOMOM_ALL_TESTS}" == "ON" ]]; then
   PROTOMOM_ADD_TEST_TARGETS="ON"
 fi
@@ -63,6 +67,8 @@ if [[ "${PROTOMOM_ALL_TESTS}" == "ON" ]]; then
 elif [[ "${PROTOMOM_SYSTEM_TESTS}" == "ON" ]]; then
   # System tests (e.g. full-executable smoke tests) are excluded by default
   ctest --test-dir "${BUILD_DIR}" -L system
+elif [[ "${PROTOMOM_MPI_TESTS}" == "ON" ]]; then
+  ctest --test-dir "${BUILD_DIR}" -L mpi
 elif [[ "${PROTOMOM_UNIT_TESTS}" == "ON" ]]; then
   ctest --test-dir "${BUILD_DIR}" -L unit
 else

--- a/config_src/drivers/solo_driver/MOM_driver.cpp
+++ b/config_src/drivers/solo_driver/MOM_driver.cpp
@@ -21,8 +21,9 @@ int main(int argc, char* argv[]) {
 
     MOM::logger::info("Hello C++ world. This is protoMOMxx!");
 
-    // Initialize the infrastructure layer (AMReX).
-    // (It is finalized automatically when this scope exits.)
+    // Initialize the infrastructure layer via MOM::Infra, a wrapper
+    // around TIM::Runtime. This initializes MPI and AMReX, which are
+    // finalized automatically when this scope exits.
     const MOM::Infra infra(argc, argv);
 
     // todo: ensemble manager (from the infrastructure layer.)

--- a/config_src/infra/CMakeLists.txt
+++ b/config_src/infra/CMakeLists.txt
@@ -7,4 +7,10 @@ target_include_directories(MOM_config_src_infra
   PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
+
+target_link_libraries(MOM_config_src_infra
+  PUBLIC
+    TIM::tim
+    MOM_src_framework
+)
 add_amrex_to_protomom_target(MOM_config_src_infra)

--- a/config_src/infra/MOM_infra.cpp
+++ b/config_src/infra/MOM_infra.cpp
@@ -1,15 +1,10 @@
 #include "MOM_infra.h"
 
-#include <AMReX.H>
-
 namespace MOM {
 
-Infra::Infra(int &argc, char **&argv) {
-    amrex::Initialize(argc, argv);
-}
-
-Infra::~Infra() {
-    amrex::Finalize();
-}
+// A thin wrapper over TIM::Runtime owner mode: the member's construction
+// does all the work (MPI_Init, then amrex::Initialize, etc.), and
+// its destruction does the ordered teardown.
+Infra::Infra(int &argc, char **&argv) : runtime_(argc, argv) {}
 
 } // namespace MOM

--- a/config_src/infra/MOM_infra.h
+++ b/config_src/infra/MOM_infra.h
@@ -1,34 +1,64 @@
 #pragma once
 /// @file MOM_infra.h
-/// @brief Startup/shutdown of the infrastructure layer (AMReX).
+/// @brief Startup/shutdown of the infrastructure layer (MPI and AMReX), as a
+///        thin wrapper over TIM::Runtime.
+
+#include <mpi.h>
+
+#include "core/tim_runtime.hpp"
 
 namespace MOM {
 
-/// @brief Starts up the infrastructure layer (AMReX) when created, and shuts
-/// it down when it goes out of scope.
+/// @brief Owns the infrastructure runtime for a solo run: brings up MPI and
+/// then AMReX (as a guest on the resulting communicator) when created, and
+/// shuts them down in reverse order when it goes out of scope.
 ///
-/// The driver creates one Infra object at the beginning of the run, which
-/// initializes AMReX. When the object goes out of scope at the end of the
-/// run, its destructor finalizes AMReX automatically (RAII).
+/// Infra is a thin wrapper over TIM::Runtime in owner mode (the analogue of
+/// MOM6's MOM_infra_init, which is itself a thin wrapper over fms_init). All
+/// of the initialization and shutdown machinery (MPI_Init/MPI_Finalize,
+/// amrex::Initialize/Finalize, and the teardown ordering) lives in
+/// TIM::Runtime. Infra keeps the familiar MOM_infra_init name and is the home
+/// for future MOM-specific communicator policy: ensemble members, or a
+/// coupler-supplied communicator adopted through TIM::Runtime's guest mode.
+/// The driver creates one Infra at the start of the run. Its destructor tears
+/// the runtime down automatically (RAII), and in correct order.
 ///
-/// todo: accept a communicator argument
+/// The communicator is MPI_COMM_WORLD for now; communicator partitioning
+/// (e.g., for ensemble members or a coupler handing the ocean a communicator)
+/// is a future extension of this class, expressed by selecting TIM::Runtime's
+/// guest-mode constructor.
 class Infra {
 public:
-  /// @brief Initialize the infrastructure layer (AMReX).
-  /// @param argc Command-line argument count (AMReX may consume arguments).
-  /// @param argv Command-line argument vector (AMReX may consume arguments).
+  /// @brief Initialize the infrastructure layer via TIM::Runtime owner mode:
+  /// MPI first, then AMReX as a guest on the owned communicator.
+  /// @param argc Command-line argument count.
+  /// @param argv Command-line argument vector.
+  ///
+  /// TIM::Runtime aborts (it does not throw) if MPI is already initialized:
+  /// Infra owns the process, and a second owner indicates a driver bug.
   Infra(int &argc, char **&argv);
 
-  /// @brief Finalize the infrastructure layer (AMReX).
-  ~Infra();
+  /// @brief Finalize the infrastructure layer (AMReX, then MPI). The work is
+  /// done by TIM::Runtime's RAII teardown.
+  ~Infra() = default;
 
-  // Exactly one Infra object should exist per run. (A copy would finalize AMReX twice).
-  // Multiple model instances are expected to share this single infrastructure runtime, 
-  // since AMReX's runtime state (communicator, parameter table, memory arenas) is global.
+  /// @brief The top-level communicator the run executes on.
+  /// @return The communicator TIM::Runtime owns (currently MPI_COMM_WORLD).
+  MPI_Comm comm() const { return runtime_.comm(); }
+
+  // Exactly one Infra object should exist per run. (A copy would tear down the
+  // runtime twice.) Multiple model instances are expected to share this single
+  // infrastructure runtime, since AMReX's runtime state (communicator,
+  // parameter table, memory arenas) is global.
   Infra(const Infra &) = delete;
   Infra &operator=(const Infra &) = delete;
   Infra(Infra &&) = delete;
   Infra &operator=(Infra &&) = delete;
+
+private:
+  /// @brief The TIM infrastructure runtime, in owner mode. Its RAII lifetime
+  /// drives MPI + AMReX startup and ordered teardown.
+  TIM::Runtime runtime_;
 };
 
 } // namespace MOM

--- a/tests/config_src/infra/CMakeLists.txt
+++ b/tests/config_src/infra/CMakeLists.txt
@@ -1,5 +1,8 @@
 add_executable(test_domain test_domain.cpp)
 target_link_libraries(test_domain GTest::gtest_main MOM_config_src_infra)
+add_executable(test_infra test_infra.cpp)
+target_link_libraries(test_infra GTest::gtest MOM_config_src_infra)
 
 include(GoogleTest)
 gtest_discover_tests(test_domain PROPERTIES LABELS "unit")
+gtest_discover_tests(test_infra PROPERTIES LABELS "unit")

--- a/tests/config_src/infra/CMakeLists.txt
+++ b/tests/config_src/infra/CMakeLists.txt
@@ -6,3 +6,9 @@ target_link_libraries(test_infra GTest::gtest MOM_config_src_infra)
 include(GoogleTest)
 gtest_discover_tests(test_domain PROPERTIES LABELS "unit")
 gtest_discover_tests(test_infra PROPERTIES LABELS "unit")
+
+find_package(MPI REQUIRED COMPONENTS CXX)  # for MPIEXEC_*
+add_test(NAME test_infra_mpi
+         COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2
+                 ${MPIEXEC_PREFLAGS} $<TARGET_FILE:test_infra> ${MPIEXEC_POSTFLAGS})
+set_tests_properties(test_infra_mpi PROPERTIES LABELS "mpi" PROCESSORS 2)

--- a/tests/config_src/infra/test_infra.cpp
+++ b/tests/config_src/infra/test_infra.cpp
@@ -6,6 +6,7 @@
 // calls on Infra's communicator, AMReX data structures/collectives, and TIM's
 // own services all work side by side in one process.
 
+#include <bit>
 #include <cstddef>
 #include <cstdint>
 #include <vector>
@@ -50,15 +51,16 @@ TEST(InfraComm, OwnedCommunicatorIsUsable) {
 // no launcher), which then owns every box.
 TEST(InfraTIMCoexistence, MultiFabReductionAndChecksum) {
   const int n = 4;
+  constexpr double fill_value = 1.5;
   const amrex::Box domain(amrex::IntVect(0), amrex::IntVect(n - 1));
   amrex::BoxArray ba(domain);
   ba.maxSize(n / 2);  // 2x2x2 boxes: 8 boxes to distribute across ranks
   const amrex::DistributionMapping dm(ba);
   amrex::MultiFab mf(ba, dm, 1, 0);
-  mf.setVal(1.5);
+  mf.setVal(fill_value);
 
   // AMReX collective reduction over the field of constants.
-  EXPECT_DOUBLE_EQ(mf.sum(), 1.5 * n * n * n);
+  EXPECT_DOUBLE_EQ(mf.sum(), fill_value * n * n * n);
 
   // Gather this rank's FABs into one contiguous buffer: TIM::checksum takes
   // one buffer per rank, and every rank must make the same single collective
@@ -77,9 +79,12 @@ TEST(InfraTIMCoexistence, MultiFabReductionAndChecksum) {
                           MPI_SUM, g_infra->comm()), MPI_SUCCESS);
   EXPECT_EQ(global_size, static_cast<unsigned long>(n) * n * n);
 
-  const int64_t sum_a = TIM::checksum(local.data(), local.size(), /*mask_val=*/nullptr);
-  const int64_t sum_b = TIM::checksum(local.data(), local.size(), /*mask_val=*/nullptr);
-  EXPECT_EQ(sum_a, sum_b) << "checksum must be deterministic";
+  constexpr auto fill_bits = std::bit_cast<uint64_t>(fill_value);
+  const auto expected_checksum =
+      static_cast<int64_t>(fill_bits * static_cast<uint64_t>(global_size));
+
+  EXPECT_EQ(expected_checksum,
+            TIM::checksum(local.data(), local.size(), /*mask_val=*/nullptr));
 }
 
 } // namespace

--- a/tests/config_src/infra/test_infra.cpp
+++ b/tests/config_src/infra/test_infra.cpp
@@ -1,0 +1,86 @@
+// Integration test for the infrastructure layer (MOM::Infra).
+//
+// Infra is a thin wrapper over TIM::Runtime: its construction initializes MPI and
+// hands the communicator to AMReX, which runs as a guest rather than as the
+// process owner. These tests verify that, with an Infra alive, direct MPI
+// calls on Infra's communicator, AMReX data structures/collectives, and TIM's
+// own services all work side by side in one process.
+
+#include <cstddef>
+#include <cstdint>
+
+#include <gtest/gtest.h>
+
+#include <AMReX_BoxArray.H>
+#include <AMReX_MultiFab.H>
+
+#include "MOM_infra.h"
+#include "tim_coms_infra.hpp"
+
+namespace {
+
+// The one Infra of this test binary, created in main() and shared by all
+// tests (exactly one Infra may exist per process).
+const MOM::Infra* g_infra = nullptr;
+
+// Infra exposes the communicator it owns, and direct MPI calls on it work
+// alongside AMReX: a collective sum of one contribution per rank equals the
+// comm size.
+TEST(InfraComm, OwnedCommunicatorIsUsable) {
+  ASSERT_NE(g_infra, nullptr);
+  int size = -1;
+  ASSERT_EQ(MPI_Comm_size(g_infra->comm(), &size), MPI_SUCCESS);
+  EXPECT_GE(size, 1);
+  int one = 1;
+  int sum = 0;
+  ASSERT_EQ(MPI_Allreduce(&one, &sum, 1, MPI_INT, MPI_SUM, g_infra->comm()),
+            MPI_SUCCESS);
+  EXPECT_EQ(sum, size);
+}
+
+// AMReX and TIM work side by side as guests of the runtime: fill a MultiFab,
+// check AMReX's own collective reduction (MultiFab::sum) against the analytic
+// answer, and run TIM::checksum over the box's data -- TIM's compiled code
+// computing inside this process.
+//
+// The unit-test harness runs on a single rank (bare MPI_Init, no launcher), so
+// this rank owns the whole single-box domain and calls the collectives once.
+TEST(InfraTIMCoexistence, MultiFabReductionAndChecksum) {
+  const int n = 4;
+  const amrex::Box domain(amrex::IntVect(0), amrex::IntVect(n - 1));
+  const amrex::BoxArray ba(domain);
+  const amrex::DistributionMapping dm(ba);
+  amrex::MultiFab mf(ba, dm, 1, 0);
+  mf.setVal(1.5);
+
+  // AMReX collective reduction over the field of constants.
+  EXPECT_DOUBLE_EQ(mf.sum(), 1.5 * n * n * n);
+
+  // On one rank there is exactly one local FAB, holding the whole domain.
+  ASSERT_EQ(mf.local_size(), 1);
+  double* data = nullptr;
+  std::size_t field_size = 0;
+  for (amrex::MFIter mfi(mf); mfi.isValid(); ++mfi) {
+    amrex::FArrayBox& fab = mf[mfi];
+    data = fab.dataPtr();
+    field_size = static_cast<std::size_t>(fab.box().numPts());
+  }
+  ASSERT_NE(data, nullptr);
+  EXPECT_EQ(field_size, static_cast<std::size_t>(n) * n * n);
+
+  const int64_t sum_a = TIM::checksum(data, field_size, /*mask_val=*/nullptr);
+  const int64_t sum_b = TIM::checksum(data, field_size, /*mask_val=*/nullptr);
+  EXPECT_EQ(sum_a, sum_b) << "checksum must be deterministic";
+}
+
+} // namespace
+
+/// @brief Test-binary entry point: initialize GTest, bring up the
+/// infrastructure layer (MPI + AMReX, via MOM::Infra over TIM::Runtime), and
+/// run all tests.
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  const MOM::Infra infra(argc, argv);
+  g_infra = &infra;
+  return RUN_ALL_TESTS();
+}

--- a/tests/config_src/infra/test_infra.cpp
+++ b/tests/config_src/infra/test_infra.cpp
@@ -8,6 +8,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -38,17 +39,20 @@ TEST(InfraComm, OwnedCommunicatorIsUsable) {
   EXPECT_EQ(sum, size);
 }
 
-// AMReX and TIM work side by side as guests of the runtime: fill a MultiFab,
+// Check that AMReX and TIM cooperate within the runtime: fill a MultiFab,
 // check AMReX's own collective reduction (MultiFab::sum) against the analytic
-// answer, and run TIM::checksum over the box's data -- TIM's compiled code
-// computing inside this process.
+// answer, and run TIM::checksum over the local data.
 //
-// The unit-test harness runs on a single rank (bare MPI_Init, no launcher), so
-// this rank owns the whole single-box domain and calls the collectives once.
+// Both reductions are collective and rank-agnostic: the domain is chopped
+// into boxes that a DistributionMapping spreads across the ranks, so under a
+// launcher multiple ranks contribute data (a rank may own several boxes, or
+// none). The unit-test harness itself runs on a single rank (bare MPI_Init,
+// no launcher), which then owns every box.
 TEST(InfraTIMCoexistence, MultiFabReductionAndChecksum) {
   const int n = 4;
   const amrex::Box domain(amrex::IntVect(0), amrex::IntVect(n - 1));
-  const amrex::BoxArray ba(domain);
+  amrex::BoxArray ba(domain);
+  ba.maxSize(n / 2);  // 2x2x2 boxes: 8 boxes to distribute across ranks
   const amrex::DistributionMapping dm(ba);
   amrex::MultiFab mf(ba, dm, 1, 0);
   mf.setVal(1.5);
@@ -56,20 +60,25 @@ TEST(InfraTIMCoexistence, MultiFabReductionAndChecksum) {
   // AMReX collective reduction over the field of constants.
   EXPECT_DOUBLE_EQ(mf.sum(), 1.5 * n * n * n);
 
-  // On one rank there is exactly one local FAB, holding the whole domain.
-  ASSERT_EQ(mf.local_size(), 1);
-  double* data = nullptr;
-  std::size_t field_size = 0;
+  // Gather this rank's FABs into one contiguous buffer: TIM::checksum takes
+  // one buffer per rank, and every rank must make the same single collective
+  // call however many boxes it owns.
+  std::vector<double> local;
   for (amrex::MFIter mfi(mf); mfi.isValid(); ++mfi) {
-    amrex::FArrayBox& fab = mf[mfi];
-    data = fab.dataPtr();
-    field_size = static_cast<std::size_t>(fab.box().numPts());
+    const amrex::FArrayBox& fab = mf[mfi];
+    const double* p = fab.dataPtr();
+    local.insert(local.end(), p, p + fab.box().numPts());
   }
-  ASSERT_NE(data, nullptr);
-  EXPECT_EQ(field_size, static_cast<std::size_t>(n) * n * n);
 
-  const int64_t sum_a = TIM::checksum(data, field_size, /*mask_val=*/nullptr);
-  const int64_t sum_b = TIM::checksum(data, field_size, /*mask_val=*/nullptr);
+  // Across ranks, the domain is held exactly once.
+  unsigned long local_size = local.size();
+  unsigned long global_size = 0;
+  ASSERT_EQ(MPI_Allreduce(&local_size, &global_size, 1, MPI_UNSIGNED_LONG,
+                          MPI_SUM, g_infra->comm()), MPI_SUCCESS);
+  EXPECT_EQ(global_size, static_cast<unsigned long>(n) * n * n);
+
+  const int64_t sum_a = TIM::checksum(local.data(), local.size(), /*mask_val=*/nullptr);
+  const int64_t sum_b = TIM::checksum(local.data(), local.size(), /*mask_val=*/nullptr);
   EXPECT_EQ(sum_a, sum_b) << "checksum must be deterministic";
 }
 


### PR DESCRIPTION
This PR links protoMOMxx to TIM and settles process ownership. The infrastructure initialization/shutdown machinery moves into TIM as `TIM::Runtime`. Instead of directly calling `AMReX::initialize/finalize`, `MOM::Infra` now simply wraps  `TIM::Runtime`.

Changes:

- TIM is now a git submodule at `extern/TIM`.
- `MOM::Infra` is reworked as a thin wrapper over `TIM::Runtime` owner mode:.
- `config_src/infra/CMakeLists.txt` links `TIM::tim`, which provides MPI transitively (so the shim header's `MPI_Comm` resolves.
- Infra integration tests.

MOM6 design/conventions carried over:
- The infrastructure layer owns MPI on the model's behalf — MOM6's fms_init/mpp_init precedent 
- Explicit, ordered teardown as an infrastructure responsibility (MOM6's MOM_infra_end).
- Owner/guest as an explicit, up-front decision. MOM6's mpp checks `MPI_INITIALIZED` to decide whether it owns MPI; `TIM::Runtime` replaces that with two explicit constructor modes: owner (`Runtime(argc, argv)`) and guest (`Runtime(MPI_Comm)`). So ownership is a choice the driver makes, not a runtime guess.

MOM6 design/conventions NOT carried over:
- Exceptions across the infrastructure boundary. TIM's C++ layer uses no exceptions and instead calls `TIM::abort` on unrecoverable startup failures.
- Implicit MPI state check to decide ownership is replaced by explicit constructor modes.
- In MOM6, FMS's mpp module keeps the active .communicator/pelist in module globals that any code can query. protoMOMxx has no such global: code that needs the communicator must call (future) `Runtime` getter functions.